### PR TITLE
wrap content if it has multiple childs

### DIFF
--- a/Kasaku.Modules.Sitecore.Sweep/Pipelines/Clean/WrapSingleTextNode.cs
+++ b/Kasaku.Modules.Sitecore.Sweep/Pipelines/Clean/WrapSingleTextNode.cs
@@ -1,4 +1,5 @@
-﻿using HtmlAgilityPack;
+﻿using System.Linq;
+using HtmlAgilityPack;
 
 namespace Kasaku.Sitecore.Modules.Sweep.Pipelines.Clean
 {
@@ -9,16 +10,14 @@ namespace Kasaku.Sitecore.Modules.Sweep.Pipelines.Clean
     {
         public override void Process(CleanPipelineArgs args)
         {
-            if (args.Document.DocumentNode.ChildNodes.Count == 1
-                 && args.Document.DocumentNode.FirstChild.NodeType == HtmlNodeType.Text)
+            if (args.Document.DocumentNode.HasChildNodes
+                 && args.Document.DocumentNode.ChildNodes.Any(node => node.NodeType == HtmlNodeType.Text))
             {
                 var newChild = HtmlNode.CreateNode("<p></p>");
-                newChild.AppendChild(args.Document.DocumentNode.FirstChild);
+                newChild.AppendChildren(args.Document.DocumentNode.ChildNodes);
 
-                args.Document.DocumentNode.ReplaceChild(
-                    newChild,
-                    args.Document.DocumentNode.FirstChild);
-
+                args.Document.DocumentNode.RemoveAllChildren();
+                args.Document.DocumentNode.AppendChild(newChild);
             }
         }
     }


### PR DESCRIPTION
Hi,
I encountered a problem with wrapping text with p-Tags. 
For example if the text in html looks like this: 
`Hello <strong>World</strong>`
Your code finds more than one childnodes and stops there. I changed your code so that it checks if there is some text on the first level under the document.